### PR TITLE
Fix Making an existing user a provider page

### DIFF
--- a/making_an_existing_user_a_provider.md
+++ b/making_an_existing_user_a_provider.md
@@ -3,16 +3,21 @@
 There are situations where a user was created and not made a provider, which causes the error as below
 
 ![Error Logged In User is Not a Provider](images/error_loggedin_user_isnotaprovider.png)
+
 The steps to make an existing user account a provider are as follows:
 1. Click Home
-    ![Legacy UI Menu](images/legacy-menu.png)
+![Legacy UI Menu](images/legacy-menu.png)
     
 2. Click the Legacy System Administration link on the home page
 ![Legacy System Administration link](images/legacy_system administration_link.png)
 3. Click the ***Manage Providers*** link on the system administration page
 ![Manage Providers link](images/manage_providers.png)
 
-3.Click ***Add Provider*** link ![Add Provider](images/add_provider.png)
-4.Enter provider name, and hit the ***save*** button ![Provider Name](images/enter_provider_name.png)
-5.You should see the newly added provider on the list as below;
+4.Click ***Add Provider*** link
+![Add Provider](images/add_provider.png)
+
+5.Enter provider name, and hit the ***save*** button
+![Provider Name](images/enter_provider_name.png)
+
+6.You should see the newly added provider on the list as below;
 ![Provider Added link](images/provider_added.png)


### PR DESCRIPTION
Correcting Making an existing user a provider page on the user manual to make it more readable